### PR TITLE
Redirecting / to /documentation and serving there

### DIFF
--- a/salt/api-gateway/config/etc-nginx-sites-enabled-proxy.conf
+++ b/salt/api-gateway/config/etc-nginx-sites-enabled-proxy.conf
@@ -25,6 +25,8 @@ server {
     location /documentation {
         alias /srv/api-raml/dist;
         index index.html;
+
+        include /etc/nginx/traits.d/error-pages.conf;
     }
 
     # kong

--- a/salt/api-gateway/config/etc-nginx-sites-enabled-proxy.conf
+++ b/salt/api-gateway/config/etc-nginx-sites-enabled-proxy.conf
@@ -18,6 +18,15 @@ server {
     access_log /var/log/nginx/access.log combined_with_time;
     error_log /var/log/nginx/error.log notice;
 
+    location = / {
+        return 301 /documentation;
+    }
+
+    location /documentation {
+        alias /srv/api-raml/dist;
+        index index.html;
+    }
+
     # kong
     location / {
         proxy_pass http://localhost:8000;

--- a/salt/api-gateway/init.sls
+++ b/salt/api-gateway/init.sls
@@ -4,6 +4,27 @@
 # nginx proxy
 # this instance sits in front of kong and proxies all requests back and forth
 #
+#
+api-documentation:
+    git.latest:
+        - name: git@github.com:elifesciences/api-raml.git
+        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - rev: master
+        - branch: master
+        - target: /srv/api-raml/
+        - force_fetch: True
+        - force_checkout: True
+        - force_reset: True
+
+    file.directory:
+        - name: /srv/api-raml
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - recurse:
+            - user
+            - group
+        - require:
+            - git: api-documentation
 
 proxy:
     file.managed:
@@ -11,6 +32,8 @@ proxy:
         - source: salt://api-gateway/config/etc-nginx-sites-enabled-proxy.conf
         - makedirs: True
         - template: jinja
+        - require:
+            - api-documentation
 
     service.running:
         - name: nginx

--- a/salt/example.top
+++ b/salt/example.top
@@ -3,4 +3,5 @@ base:
         - elife
         - elife.postgresql
         - elife.nginx
+        - elife.nginx-error-pages
         - api-gateway


### PR DESCRIPTION
Had to go for a redirect to `/documentation` because serving directly from `/` would be ambiguous for path such as `/samples`, `/model` (are they files or APIs?)

Also the error-pages work only in `/documentation/...` (and they couldn't work otherwise as `/does-not-exist` will be passed down to Kong).