### PR TITLE
logrotate, reduces number of logs to keep to 2 days.

### DIFF
--- a/salt/api-gateway/config/etc-logrotate.d-kong
+++ b/salt/api-gateway/config/etc-logrotate.d-kong
@@ -1,6 +1,6 @@
 /usr/local/kong/logs/*.log {
     daily
-    rotate 3
+    rotate 2
     dateext
     notifempty
     missingok
@@ -10,7 +10,7 @@
 
 /var/log/kong/*.log {
     daily
-    rotate 3
+    rotate 2
     dateext
     notifempty
     missingok


### PR DESCRIPTION
Reduces the number of days to keep kong logs around for to two days.

We have the article.log file growing very fast at the moment and disk space has been pinched since the docker container was introduced. We don't really inspect these logs and all the data is sent to loggly. A better solution is required but this will do for now.

fyi @NuclearRedeye 