### PR TITLE
admin logs mount

### DIFF
--- a/salt/api-gateway/config/opt-kong-docker-compose.yaml
+++ b/salt/api-gateway/config/opt-kong-docker-compose.yaml
@@ -23,3 +23,4 @@ services:
             # directories (host:container)
             # these paths are specified in `loris2.conf`
             - /var/log/kong:/var/log/kong
+            - /usr/local/kong/logs:/usr/local/kong/logs

--- a/salt/api-gateway/kong.sls
+++ b/salt/api-gateway/kong.sls
@@ -95,6 +95,8 @@ kong-admin-calls-logs:
         - user: nobody
         - group: root
         - dir_mode: 755
+        # directory doesn't exist post-containerisation on fresh builds, however other config still expects it there
+        - makedirs: true 
         - recurse:
             - mode
 

--- a/salt/api-gateway/kong.sls
+++ b/salt/api-gateway/kong.sls
@@ -82,6 +82,16 @@ kong-docker-compose:
 kong-api-calls-logs:
     file.directory:
         - name: /var/log/kong
+        - makedirs: true
+        - user: nobody
+        - group: root
+        - dir_mode: 755
+        - recurse:
+            - mode
+
+kong-admin-calls-logs:
+    file.directory:
+        - name: /usr/local/kong/logs
         - user: nobody
         - group: root
         - dir_mode: 755
@@ -158,6 +168,7 @@ kong-container-service:
             - kong-config
             - kong-db-exists
             - kong-api-calls-logs
+            - kong-admin-calls-logs
         - watch:
             - kong-docker-compose
             - kong-config


### PR DESCRIPTION
adds volume mount for /usr/local/kong/logs to docker-compose.
otherwise these accumulate within the container.
pretty certain these are the admin logs rather than api logs